### PR TITLE
Make the Poll Time Setting Actually Set the Poll Time

### DIFF
--- a/watcher/watchman
+++ b/watcher/watchman
@@ -41,7 +41,7 @@ for record in tree.findall("path"):
     folders[f.location] = f
     logging.info("Setting up watched folder at {0}, stable time is {1}.".format(f.location,f.stable_time))
     logging.debug("Watched folder {0} has ignorelist {1}".format(f.location,f.ignorelist))
-    s = WatchDogBasedSystem(location=f.location, stable_time=f.stable_time, ignorelist=f.ignorelist)
+    s = WatchDogBasedSystem(location=f.location, poll_delay=f.polltime, stable_time=f.stable_time, ignorelist=f.ignorelist)
     s.daemon = True
     folders[f.location].kennel = s
     s.start()


### PR DESCRIPTION
The poll time setting will now be used to set the poll time. It currently defaults to one second.

This should make processing clashes between nodes much less likely.

@fredex42 