### PR TITLE
Logging Improvements

### DIFF
--- a/watcher/blacklist.py
+++ b/watcher/blacklist.py
@@ -12,6 +12,8 @@ class WatchmanBlacklist(object):
         try:
             self.set_log_level(loglevel)
         except Exception:
+            if loglevel is not None:
+                logging.warning("Attempt at setting log level {0} failed.".format(loglevel))
             pass
         if config_xml is None:
             config_xml = ET.parse(CONFIG_FILE)

--- a/watcher/blacklist.py
+++ b/watcher/blacklist.py
@@ -7,7 +7,12 @@ import logging
 
 
 class WatchmanBlacklist(object):
-    def __init__(self, config_xml = None):
+    def __init__(self, config_xml = None, location=None, loglevel=None):
+        self.logger = logging.getLogger('WatchmanBlacklist.{0}'.format(location))
+        try:
+            self.set_log_level(loglevel)
+        except Exception:
+            pass
         if config_xml is None:
             config_xml = ET.parse(CONFIG_FILE)
         #elif not isinstance(config_xml,ET.Element) and not isinstance(config_xml,ET.ElementTree):
@@ -27,18 +32,22 @@ class WatchmanBlacklist(object):
             expire = config_xml.find('/global/expire').text
             self.expire = int(expire)
         except StandardError as e:
-            logging.warning("No <expire> setting in the <global> section of config. Defaulting to 360s.")
+            self.logger.warning("No <expire> setting in the <global> section of config. Defaulting to 360s.")
             self.expire = 360
 
         try:
             dbnum = config_xml.find('/global/blacklistdb').text
             self._dbnum = int(dbnum)
         except StandardError as e:
-            logging.warning("No blacklistdb setting in the <global> section of config. Defaulting to Redis database 2.")
+            self.logger.warning("No blacklistdb setting in the <global> section of config. Defaulting to Redis database 2.")
             dbnum = 2
 
         self._conn = StrictRedis(host=redishost, password=password, db=dbnum)
-        
+
+    def set_log_level(self, level):
+        level_to_set = logging.getLevelName(level)
+        self.logger.setLevel(level_to_set)
+
     def get(self,filepath,update=True,value="(locked)"):
         """
         Check if the given path is in the blacklist, and optionally update the lock whether or not it exists
@@ -55,7 +64,7 @@ class WatchmanBlacklist(object):
         #    self._conn.expire(filepath, self.expire)
 
         if not self._conn.exists(filepath):
-            logging.debug("{0} does not exist in the blacklist. Attempting to add it.".format(filepath))
+            self.logger.debug("{0} does not exist in the blacklist. Attempting to add it.".format(filepath))
             self._conn.setnx(filepath, value)
             self._conn.expire(filepath, self.expire)
         

--- a/watcher/global_settings.py
+++ b/watcher/global_settings.py
@@ -4,5 +4,5 @@ import logging
 CONFIG_FILE="/etc/ffqueue-config.xml"
 LOGFORMAT = '%(asctime)-15s - [%(filename)s] %(threadName)s %(funcName)s: %(levelname)s - %(message)s'
 LOGFORMAT_RUNNER = '%(asctime)-15s - [%(filename)s] %(threadName)s %(funcName)s: %(levelname)s - (%(watchfolder)s) %(message)s'
-LOGLEVEL = logging.DEBUG
+LOGLEVEL = logging.INFO
 LOGFILE = "/var/log/watchman/watchman.log"

--- a/watcher/watchedfolder.py
+++ b/watcher/watchedfolder.py
@@ -9,7 +9,7 @@ class WatchedFolder(object):
     Code that handles the reading of the XML based configuration file
     """
     def __init__(self, record=None, location=None, debuglevel=None, polltime=None, stable_time=None, commandlist=None,
-                 raven_client=None, suid_cds=False):
+                 raven_client=None, suid_cds=False, loglevel=None):
         """
         Method which sets default values of various paramarters
         :param record: Misc. data
@@ -24,6 +24,7 @@ class WatchedFolder(object):
         self.location=location
         self.debuglevel=debuglevel
         self.polltime=polltime
+        self.loglevel=loglevel
         self.stable_time=stable_time
         self.commandlist=commandlist
         self.description=""
@@ -35,6 +36,7 @@ class WatchedFolder(object):
             self.location=record.attrib['location']
             self.debuglevel=self._safe_get(record, 'debuglevel')
             self.polltime=self._safe_get(record, "poll-time")
+            self.loglevel=self._safe_get(record, "log-level")
             self.description=self._safe_get(record, "desc")
             self.commandlist=self._safe_get_list(record, "command")
             self.ignorelist=self._safe_get(record,"ignore").split('|')

--- a/watcher/watchman
+++ b/watcher/watchman
@@ -53,7 +53,7 @@ for record in tree.findall("path"):
     folders[f.location] = f
     logging.info("Setting up watched folder at {0}, stable time is {1}.".format(f.location,f.stable_time))
     logging.debug("Watched folder {0} has ignorelist {1}".format(f.location,f.ignorelist))
-    s = WatchDogBasedSystem(location=f.location, poll_delay=f.polltime, stable_time=f.stable_time, ignorelist=f.ignorelist)
+    s = WatchDogBasedSystem(location=f.location, poll_delay=f.polltime, stable_time=f.stable_time, ignorelist=f.ignorelist, loglevel=f.loglevel)
     s.daemon = True
     folders[f.location].kennel = s
     s.start()

--- a/watcher/watchman
+++ b/watcher/watchman
@@ -30,6 +30,18 @@ folders = {}
 tree = ET.parse(CONFIG_FILE)
 root = tree.getroot()
 
+
+def set_log_level(level):
+    level_to_set = logging.getLevelName(level)
+    logging.getLogger().setLevel(level_to_set)
+
+
+try:
+    log_level = tree.find('/global/log-level').text
+    set_log_level(log_level)
+except Exception:
+    pass
+
 try:
     raven_client = RavenClient(get_dsn(tree), raise_exception=True)
 except DSNNotFound:

--- a/watcher/watchpuppy.py
+++ b/watcher/watchpuppy.py
@@ -33,8 +33,8 @@ class WatchDogBasedSystem(threading.Thread):
         self.loglevel = loglevel
 
     def set_log_level(self, level):
-        level_to_set = self.logging.getLevelName(level)
-        self.logging.getLogger().setLevel(level_to_set)
+        level_to_set = logging.getLevelName(level)
+        logging.getLogger().setLevel(level_to_set)
 
     def run(self):
         """
@@ -48,7 +48,7 @@ class WatchDogBasedSystem(threading.Thread):
         from blacklist import WatchmanBlacklist
 
         try:
-            self.set_log_level(self, self.loglevel)
+            self.set_log_level(self.loglevel)
         except Exception:
             pass
         

--- a/watcher/watchpuppy.py
+++ b/watcher/watchpuppy.py
@@ -23,7 +23,7 @@ class WatchDogBasedSystem(threading.Thread):
         :param kwargs: (other arguments for threading.Thread)
         """
         super(WatchDogBasedSystem, self).__init__(*args,**kwargs)
-        self.logger = logging.getLogger('WatchDogBasedSystem')
+        self.logger = logging.getLogger('WatchDogBasedSystem.{0}'.format(location))
         self.path=location
         self.wonderfullist = {}
         self.poll_delay = poll_delay
@@ -34,7 +34,7 @@ class WatchDogBasedSystem(threading.Thread):
 
     def set_log_level(self, level):
         level_to_set = logging.getLevelName(level)
-        logging.getLogger().setLevel(level_to_set)
+        self.logger.setLevel(level_to_set)
 
     def run(self):
         """

--- a/watcher/watchpuppy.py
+++ b/watcher/watchpuppy.py
@@ -13,7 +13,7 @@ class WatchDogBasedSystem(threading.Thread):
     """
     from watchdog.events import FileSystemEventHandler
 
-    def __init__(self, location=None, poll_delay=1, stable_time=10, recursive=False, ignorelist=[], *args, **kwargs):
+    def __init__(self, location=None, poll_delay=1, stable_time=10, recursive=False, ignorelist=[], loglevel=None, *args, **kwargs):
         """
         Initialise the system
         :param location: (string) Path to the directory to watch
@@ -30,6 +30,11 @@ class WatchDogBasedSystem(threading.Thread):
         self.stable_time = stable_time
         self.recursive = recursive
         self.ignorelist = ignorelist
+        self.loglevel = loglevel
+
+    def set_log_level(self, level):
+        level_to_set = self.logging.getLevelName(level)
+        self.logging.getLogger().setLevel(level_to_set)
 
     def run(self):
         """
@@ -41,6 +46,11 @@ class WatchDogBasedSystem(threading.Thread):
         import os
         from tasks import action_file
         from blacklist import WatchmanBlacklist
+
+        try:
+            self.set_log_level(self, self.loglevel)
+        except Exception:
+            pass
         
         blacklist = WatchmanBlacklist()
         

--- a/watcher_config/example_config.xml
+++ b/watcher_config/example_config.xml
@@ -9,6 +9,7 @@
 		<result-backend>**result backend url here**</result-backend>
 		<!-- If you want to get exceptions reported to Sentry, put a DSN in here -->
 		<!--<raven-dsn></raven-dsn>-->
+		<log-level>INFO</log-level>
 	</global>
 
 	<!--add watchfolder definitions here-->


### PR DESCRIPTION
Changes the default log level to INFO.

Adds support for loading the global log level from the <log-level> tag if present. Legal values are CRITICAL, ERROR, WARNING, INFO, and DEBUG. This value is then used to change the log level setting of the main logger object.

Adds support for loading path specific log levels from the <log-level> tag if present for that path. Legal values are CRITICAL, ERROR, WARNING, INFO, and DEBUG. This value is then used to change the log level of unique child logger objects called from the WatchDogBasedSystem and WatchmanBlacklist classes.

Tested on a local virtual machine.

@fredex42 